### PR TITLE
upgrade alpine linux to 3.16.1 and make IPV4 CIRD flexible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1
+FROM alpine:3.16.1
 
 LABEL maintainer="Alexander Litvinenko <array.shift@yahoo.com>"
 
@@ -12,7 +12,7 @@ COPY scripts .
 COPY config ./config
 COPY VERSION ./config
 
-RUN apk add --no-cache openvpn easy-rsa bash netcat-openbsd zip dumb-init && \
+RUN apk add --no-cache iptables ipcalc openvpn easy-rsa bash netcat-openbsd zip dumb-init && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/bin/easyrsa && \
     mkdir -p ${APP_PERSIST_DIR} && \
     cd ${APP_PERSIST_DIR} && \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -60,6 +60,16 @@ EOF4
     touch $LOCKFILE
 fi
 
+# Set default value to IPV4_CIDR if it was not set from environment
+if [ -z "$IPV4_CIDR" ]
+then
+    IPV4_CIDR='10.8.0.0/24'
+fi
+
+# write server network by IPV4_CIDR into server.conf
+IPV4_SERVER="server $(ipcalc -4 -a $IPV4_CIDR | sed  's/^ADDRESS*=//') $(ipcalc  -4 -m $IPV4_CIDR  | sed  's/^NETMASK*=//')"
+sed  -i "s/^server.*/$IPV4_SERVER/g" /etc/openvpn/server.conf
+
 # Copy server keys and certificates
 cp pki/ca.crt pki/issued/MyReq.crt pki/private/MyReq.key pki/crl.pem ta.key /etc/openvpn
 


### PR DESCRIPTION
After I upgrade to 3.14.1 it was necessary to include iptables.

the IPV4 CIRD SERVER correction is in the start, because in the function. It was not working for me.

By the way It works with podman with little changes:
```
export FULL_VERSION_RELEASE="$$(cat ./VERSION)"
export FULL_VERSION="$$(cat ./VERSION)-regen-dh"
export DOCKER_REPO="localhost/openvpn"

.PHONY: clean build

all: clean build

clean:
	{ podman images | grep openvpn | awk '{ print $3}' | xargs podman rmi -f ; } >/dev/null 2>&1

build:
	@echo "Making production version ${FULL_VERSION} of DockOvpn"
	sudo podman build -t "${DOCKER_REPO}:${FULL_VERSION}" -t "${DOCKER_REPO}:latest" . --no-cache


run:
	sudo podman run --rm --cap-add=NET_ADMIN,NET_RAW --device=/dev/net/tun \
	-v config:/opt/Dockovpn_data \
	-p 1194:1194/udp -p 8080:8080/tcp \
	-e HOST_ADDR=195.201.127.81  -e IPV4_CIDR=10.10.0.0/24 \
	--rm \
	${DOCKER_REPO}
```