### PR TITLE
Move PKI initialization to app start phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,6 @@ COPY VERSION ./config
 RUN apk add --no-cache openvpn easy-rsa bash netcat-openbsd zip dumb-init && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/bin/easyrsa && \
     mkdir -p ${APP_PERSIST_DIR} && \
-    cd ${APP_PERSIST_DIR} && \
-    easyrsa init-pki && \
-    easyrsa gen-dh && \
-    # DH parameters of size 2048 created at /usr/share/easy-rsa/pki/dh.pem
-    # Copy DH file
-    cp pki/dh.pem /etc/openvpn && \
     # Copy FROM ./scripts/server/conf TO /etc/openvpn/server.conf in DockerFile
     cd ${APP_INSTALL_PATH} && \
     cp config/server.conf /etc/openvpn/server.conf

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,6 +33,9 @@ LOCKFILE=.gen
 if [ ! -f $LOCKFILE ]; then
     IS_INITIAL="1"
 
+    easyrsa init-pki
+    easyrsa gen-dh
+
     easyrsa build-ca nopass << EOF
 
 EOF
@@ -62,7 +65,7 @@ EOF4
 fi
 
 # Copy server keys and certificates
-cp pki/ca.crt pki/issued/MyReq.crt pki/private/MyReq.key pki/crl.pem ta.key /etc/openvpn
+cp pki/dh.pem pki/ca.crt pki/issued/MyReq.crt pki/private/MyReq.key pki/crl.pem ta.key /etc/openvpn
 
 cd "$APP_INSTALL_PATH"
 


### PR DESCRIPTION
Hello, thank you for the Dockerized OpenVPN all works well.
But I've encountered that with persistent volume the image doesn't work. I've found that this is due to PKI and DH files creation during the image build phase. I've moved creation of this files to the app start phase. So if them are already generated they won't be generated further. All works on my instance well.

Also I've found that this PR will solve following issues: https://github.com/dockovpn/dockovpn/issues/184 https://github.com/dockovpn/dockovpn/issues/174