### PR TITLE
Use /opt/Dockovpn_data in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
     environment:
         HOST_ADDR: ${HOST_ADDR} 
     volumes:
-        - ./openvpn_conf:/doc/Dockovpn
+        - ./openvpn_conf:/opt/Dockovpn_data
     restart: always


### PR DESCRIPTION
The data is actually stored in `/opt/Dockovpn_data` within the container. However the example `docker-compose.yml` currently uses `/doc/Dockovpn`.