### PR TITLE
Remove request to `ip.dockovpn.io` server if `HOST_ADDR` is set and fix some warnings

### DIFF
--- a/config/server.conf
+++ b/config/server.conf
@@ -13,7 +13,7 @@ push "dhcp-option DNS 208.67.220.220"
 duplicate-cn
 keepalive 10 120
 cipher AES-256-GCM
-ncp-ciphers AES-256-GCM:AES-256-CBC
+data-ciphers AES-256-GCM:AES-256-CBC
 auth SHA512
 persist-key
 persist-tun

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -199,10 +199,10 @@ function generateClientConfig() {
     echo "$(datef) Config http server has been shut down"
 }
 
-RESOLVED_HOST_ADDR=$(curl -s -H "X-DockoVPN-Version: $(getVersion) $0" https://ip.dockovpn.io)
 
 if [[ -n $HOST_ADDR ]]; then
     export HOST_ADDR_INT=$HOST_ADDR
 else
+    RESOLVED_HOST_ADDR=$(curl -s -H "X-DockoVPN-Version: $(getVersion) $0" https://ip.dockovpn.io)
     export HOST_ADDR_INT=$RESOLVED_HOST_ADDR
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -69,7 +69,7 @@ cd "$APP_PERSIST_DIR"
 
 LOCKFILE=.gen
 
-# Regenerate certs only on the first start 
+# Regenerate certs only on the first start
 if [ ! -f $LOCKFILE ]; then
     IS_INITIAL="1"
 
@@ -100,7 +100,7 @@ yes
 EOF3
     # Certificate created at: /opt/Dockovpn_data/pki/issued/MyReq.crt
 
-    openvpn --genkey --secret ta.key << EOF4
+    openvpn --genkey secret ta.key << EOF4
 yes
 EOF4
 


### PR DESCRIPTION
I don't know why this request is sent every time container start, but if it's telemetry, you should mention it at least somewhere.

This PR also fixes those warnings:
 - `Note: Treating option '--ncp-ciphers' as  '--data-ciphers' (renamed in OpenVPN 2.5).`
 - `WARNING: Using --genkey --secret filename is DEPRECATED.  Use --genkey secret filename instead.`