### PR TITLE
Fix: pki data lost when mounting empty volume

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -72,7 +72,7 @@ LOCKFILE=.gen
 # Regenerate certs only on the first start 
 if [ ! -f $LOCKFILE ]; then
     IS_INITIAL="1"
-
+    test -d pki || REGENERATE="1"
     if [[ -n $REGENERATE ]]; then
         easyrsa --batch init-pki
         easyrsa --batch gen-dh


### PR DESCRIPTION
When mounting an empty directory to /opt/Dockovpn data in docker-compose.yml, the pki data should be automatically regenerated